### PR TITLE
Updated README example because it was causing a PHP warning

### DIFF
--- a/README
+++ b/README
@@ -68,7 +68,7 @@ else
 {
     $params = array('code' => $_GET['code'], 'redirect_uri' => REDIRECT_URI);
     $response = $client->getAccessToken(TOKEN_ENDPOINT, 'authorization_code', $params);
-    parse_str($response['result'], $info);
+    $info = $response['result'];
     $client->setAccessToken($info['access_token']);
     $response = $client->fetch('https://graph.facebook.com/me');
     var_dump($response, $response['result']);


### PR DESCRIPTION
Replaced parse_str($response['result'], $info); with $info = $response['result']; in README authorization example.

parse_str($response['result'], $info); causes a PHP warning that parse_str() expects an array, but $response['result'] is a string.
