### PR TITLE
Fix wrong post query seprator on some PHP install

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -379,7 +379,7 @@ class Client
                  * http://php.net/manual/en/function.curl-setopt.php
                  */
                 if(is_array($parameters) && self::HTTP_FORM_CONTENT_TYPE_APPLICATION === $form_content_type) {
-                    $parameters = http_build_query($parameters);
+                    $parameters = http_build_query($parameters, null, '&');
                 }
                 $curl_options[CURLOPT_POSTFIELDS] = $parameters;
                 break;


### PR DESCRIPTION
On some PHP install the default separator of http_build_query() is not "&". So, I have to set the separator to "&" in "http_build_query()".
