### PR TITLE
Add support for HTTP PATCH verb

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -59,6 +59,7 @@ class Client
     const HTTP_METHOD_PUT    = 'PUT';
     const HTTP_METHOD_DELETE = 'DELETE';
     const HTTP_METHOD_HEAD   = 'HEAD';
+    const HTTP_METHOD_PATCH   = 'PATCH';
 
     /**
      * HTTP Form content types
@@ -402,6 +403,7 @@ class Client
                 $curl_options[CURLOPT_POST] = true;
                 /* No break */
             case self::HTTP_METHOD_PUT:
+			case self::HTTP_METHOD_PATCH:
 
                 /**
                  * Passing an array to CURLOPT_POSTFIELDS will encode the data as multipart/form-data,


### PR DESCRIPTION
Handled by the OAuth2\Client the same way as PUT. Tested and working with the [Salesforce.com REST API](http://www.salesforce.com/us/developer/docs/api_rest/) which [requires](http://www.salesforce.com/us/developer/docs/api_rest/Content/dome_update_fields.htm)  it.

See [RFC 5789](http://tools.ietf.org/html/rfc5789).
