### PR TITLE
Fixes SSL Connection Timeout issues

### DIFF
--- a/src/OAuth2/Client.php
+++ b/src/OAuth2/Client.php
@@ -395,7 +395,8 @@ class Client
         $curl_options = array(
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_CUSTOMREQUEST  => $http_method
+            CURLOPT_CUSTOMREQUEST  => $http_method,
+            CURLOPT_SSLVERSION => 3
         );
 
         switch($http_method) {


### PR DESCRIPTION
SSL would timeout on my vagrant ubuntu precise32 virtualmachine even when I had CURLOPT_SSL_VERIFYPEER set to false. Found this hidden little gem on stackoverflow. 

http://stackoverflow.com/questions/24975238/ssl-connection-error-even-when-verifypeer-verifyhost-disabled