### PR TITLE
Fix for deprecated function in http_build_query

### DIFF
--- a/src/OAuth2/Client.php
+++ b/src/OAuth2/Client.php
@@ -196,7 +196,7 @@ class Client
             'client_id'     => $this->client_id,
             'redirect_uri'  => $redirect_uri
         ), $extra_parameters);
-        return $auth_endpoint . '?' . http_build_query($parameters, null, '&');
+        return $auth_endpoint . '?' . http_build_query($parameters, '', '&');
     }
 
     /**


### PR DESCRIPTION
Exception Message in PHP8:
http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated