### PR TITLE
Add PHP version check for cURL resource closure

### DIFF
--- a/src/OAuth2/Client.php
+++ b/src/OAuth2/Client.php
@@ -401,7 +401,7 @@ class Client
      * @param int    $form_content_type HTTP form content type to use
      * @return array
      */
-    private function executeRequest($url, $parameters = array(), $http_method = self::HTTP_METHOD_GET, array $http_headers = null, $form_content_type = self::HTTP_FORM_CONTENT_TYPE_MULTIPART)
+    private function executeRequest($url, $parameters = array(), $http_method = self::HTTP_METHOD_GET, ?array $http_headers = null, $form_content_type = self::HTTP_FORM_CONTENT_TYPE_MULTIPART)
     {
         $curl_options = array(
             CURLOPT_RETURNTRANSFER => true,

--- a/src/OAuth2/Client.php
+++ b/src/OAuth2/Client.php
@@ -474,7 +474,11 @@ class Client
         } else {
             $json_decode = json_decode($result, true);
         }
-        curl_close($ch);
+        
+		// Deprecated since PHP 8.0
+		if (PHP_VERSION_ID < 80000 && is_resource($this->curl)) {
+		    curl_close($this->curl);
+		}
 
         return array(
             'result' => (null === $json_decode) ? $result : $json_decode,


### PR DESCRIPTION
Added a check for PHP version before closing the cURL resource.

Deprecated: Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in /customers/1/a/7/ksomware.be/httpd.www/Ksom/vendor/adoy/oauth2/src/OAuth2/Client.php on line 477